### PR TITLE
destroy_containers: wait containers to start

### DIFF
--- a/docker-stress
+++ b/docker-stress
@@ -138,7 +138,7 @@ def main():
     except KeyboardInterrupt:
         pass
     finally:
-        print "Terminating workers and cleaning up..."
+        print "Terminating workers and cleaning up...(in background)"
         kill_workers()
         destroy_containers(client, nametag)
 

--- a/spotify/docker_stress/docker_client.py
+++ b/spotify/docker_stress/docker_client.py
@@ -97,11 +97,20 @@ class CliDockerClient(object):
         log.debug('destroy %s', container_id)
         self.cli_check('rm', container_id)
 
-    def list_containers(self, needle=''):
+    def list_containers(self, needle='', _all=False):
         if not needle:
             return self.cli_check('ps', '-q').splitlines()
         else:
-            lines = self.cli_check('ps').splitlines()[1:]
+            if _all:
+                lines = self.cli_check('ps', '-a').splitlines()[1:]
+            else:
+                lines = self.cli_check('ps').splitlines()[1:]
             matches = [word for line in lines for word in line.split() if needle in word]
             log.debug('list_containers: needle=%s, matches=%s', needle, matches)
             return matches
+
+    def list_all_exited(self, needle):
+	lines = self.cli_check('ps', '-a').splitlines()[1:]
+	lines = [line for line in lines if 'Exited' in line]
+	matches = [word for line in lines for word in line.split() if needle in word]
+	return matches


### PR DESCRIPTION
If use vfs graphdriver for docker, we can start cleanup before
all docker-containers are started, so can leave behind some ct
or after some container had stopped. After 1h print debug message
that we can not stop all containers.

Signed-off-by: Pavel Tikhomirov <ptikhomirov@parallels.com>